### PR TITLE
feat: long dash (em-dash) smart spacing

### DIFF
--- a/test/unidecode.mocha.js
+++ b/test/unidecode.mocha.js
@@ -78,6 +78,11 @@ describe('Smart spacing', function() {
     assert.equal(unidecode('Café 北京, 鞋 size 10½, 33⅓ RPM', { smartSpacing: true }), 'Cafe Bei Jing, Xie size 10 1/2, 33 1/3 RPM');
   });
 
+  it('should replace an em-dash straddled by word characters with " - " instead of "--"', function() {
+    assert.equal(
+      unidecode("No—I mean yes!", { smartSpacing: true }), "No - I mean yes!");
+  });
+
   it('should handle deferred smart spacing', function() {
     var str = unidecode('Café 北京, 鞋 size 10½, 33⅓ RPM', { deferredSmartSpacing: true });
     assert.ok(/[\x80\x81]/.test(str));

--- a/unidecode.js
+++ b/unidecode.js
@@ -105,8 +105,14 @@ function unidecode_internal_replace(ch) {
 }
 
 function resolveSpacing(str) {
-  return str.replace(/\x80(?!\w)/g, '').replace(/\x80\x80|(\w)\x80/g, '$1\x81').replace(/\x80/g, '')
-    .replace(/^\x81+|\x81+$/g, '').replace(/\x81 \x81/g, '  ').replace(/\s?\x81+/g, ' ');
+  return str
+    .replace(/\x80(?!\w)/g, "")
+    .replace(/\x80\x80|(\w)\x80/g, "$1\x81")
+    .replace(/\x80/g, "")
+    .replace(/^\x81+|\x81+$/g, "")
+    .replace(/\x81 \x81/g, "  ")
+    .replace(/\s?\x81+/g, " ")
+    .replace(/(\w)(--)(\w)/g, (_, p1, _2, p3) => `${p1} - ${p3}`);
 }
 
 module.exports.resolveSpacing = resolveSpacing;


### PR DESCRIPTION
Hey there! Thanks for building some great new features for the unidecode package!

I thought I could make an improvement to the smartSpacing option, so I've done that below. 

I always find myself chaining this extra .replace() call after running unidecode, so I thought it might be quite a common thing that people find themselves doing.

You may, however, see situations in which this could pose an issue, and if so, feel free to scrap it!

Cheers,
Steven