### PR TITLE
Handle falsey values

### DIFF
--- a/unidecode.js
+++ b/unidecode.js
@@ -40,6 +40,8 @@ var smartSpacing = false;
 var skipRanges;
 
 module.exports = function unidecode(str, options) {
+  if (!str) return '';
+  
   german = options && options.german;
   deferredSmartSpacing = options && options.deferredSmartSpacing;
   smartSpacing = deferredSmartSpacing || (options && options.smartSpacing);


### PR DESCRIPTION
Previously, if a falsey value was passed (e.g. `null` or `undefined`), an error would occur. This change returns an empty string instead.

It also has the side benefit of short-circuiting for an empty string, because there's no need to replace anything.